### PR TITLE
SRE-4326 Swap the PackageName and PackageRefName

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -54,7 +54,7 @@ pipeline {
             steps {
                 script {
                     def packages = [
-                        [packageName: "StackExchange.Opserver", packageReferenceName: "Configure IIS site", packageVersion: "${env.VERSION}"]
+                        [packageName: "Configure IIS site", packageReferenceName: "StackExchange.Opserver", packageVersion: "${env.VERSION}"]
                     ]
 
                     octopusCreateRelease \


### PR DESCRIPTION
I can see from the generated command that the previous change made the --package option change. 

Seeing if this makes it match the other docs.
```
[Optional] Version number to use for a package
                             in the release. Format: StepName:Version or
                             PackageID:Version or
                             StepName:PackageName:Version. StepName,
                             PackageID, and PackageName can be replaced with
                             an asterisk. An asterisk will be assumed for
                             StepName, PackageID, or PackageName if they are
                             omitted.
```
from https://octopus.com/docs/octopus-rest-api/octopus-cli/create-release 

https://jenkins.rktapps.com/blue/organizations/jenkins/DevOps%2FOpserver/detail/pushpay_master/14/pipeline/ had
`--package "StackExchange.Opserver:Configure IIS site:1.1.0.14" --project Opserver`

So seeing if swapping the keys puts it in the "right" order